### PR TITLE
update ndk version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,8 @@ jobs:
           distribution: "temurin"
       - uses: android-actions/setup-android@v3
       - run: |
-          sdkmanager --install "ndk;27.0.12077973"
-          echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.0.12077973" >> $GITHUB_ENV
+          sdkmanager --install "ndk;28.2.13676358"
+          echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/28.2.13676358" >> $GITHUB_ENV
       - run: |
           ls $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/
           ls $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
@@ -202,10 +202,6 @@ jobs:
         with:
           name: sqlite-better-trigram-android-x86_64-extension
           path: dist/android-x86_64
-      - uses: actions/download-artifact@v4
-        with:
-          name: sqlite-better-trigram-android-armv7a-extension
-          path: dist/android-armv7a
       - uses: actions/download-artifact@v4
         with:
           name: sqlite-better-trigram-android-armv7a-extension


### PR DESCRIPTION
Hi, thank you for this tokenizer! It works perfectly
 
 ## Context
Google Play requires 16KB page size alignment since **November 1st 2025** 

## Solution
NDK version r28 and higher compile 16 KB-aligned by default. [source](https://developer.android.com/guide/practices/page-sizes#compile-r28)

NDK r27 needs additional linker flags to be added. [source](https://developer.android.com/guide/practices/page-sizes#compile-r27)
```
-Wl,-z,max-page-size=16384
```

