### PR TITLE
allow for relinking on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ CONDITIONAL_CFLAGS = -lm
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 	EXT = .dylib
+	# handle macOS path re-linking
+	override CFLAGS += -Wl,-headerpad_max_install_names
 endif
 
 .PHONY: all clean test


### PR DESCRIPTION
I am trying to use this library on macos but when linking I am getting this

```bash
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: changing install names or rpaths can't be redone for:/better_trigram_mac_arm64.dylib (for architecture arm64) because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
```

This PR adds the neccessary flags to have a larger pad to allow relinking