### PR TITLE
Better handling of Japanese text

### DIFF
--- a/better-trigram.test.ts
+++ b/better-trigram.test.ts
@@ -821,6 +821,79 @@ describe("cjk", () => {
     [],
     ["(some) (李红)：不，那不 text 是杂志。in 那是 chinese 字典。"]
   );
+
+  test("1.5 (Japanese Setup)", () => {
+    [
+      `INSERT INTO t1 VALUES('リンゴを食べます。');`,
+      `INSERT INTO t1 VALUES('半角ｶﾀｶﾅと、句読点。');`,
+      `INSERT INTO t1 VALUES('「こんにちは」と言った。');`,
+      `INSERT INTO t1 VALUES('ｆｕｌｌｗｉｄｔｈのテスト');`,
+      `INSERT INTO t1 VALUES('ﾊﾝｶｸのﾃｽﾄ');`,
+    ].forEach((stmt) => db.query(stmt).run());
+  });
+
+  // Full-width Katakana
+  sqlTest(
+    db,
+    `1.6`,
+    `SELECT highlight(t1, 0, '(', ')') as res FROM t1('リンゴ');`,
+    [],
+    ["(リンゴ)を食べます。"]
+  );
+
+  // Kanji + Hiragana (The exact issue your PR fixes)
+  sqlTest(
+    db,
+    `1.7`,
+    `SELECT highlight(t1, 0, '(', ')') as res FROM t1('食べ');`,
+    [],
+    ["リンゴを(食べ)ます。"]
+  );
+
+  // Half-width Katakana
+  sqlTest(
+    db,
+    `1.8`,
+    `SELECT highlight(t1, 0, '(', ')') as res FROM t1('ｶﾀｶﾅ');`,
+    [],
+    ["半角(ｶﾀｶﾅ)と、句読点。"]
+  );
+
+  // Japanese Punctuation (Comma / Ideographic Comma)
+  sqlTest(
+    db,
+    `1.9`,
+    `SELECT highlight(t1, 0, '(', ')') as res FROM t1('、');`,
+    [],
+    ["半角ｶﾀｶﾅと(、)句読点。"]
+  );
+
+  // Japanese Punctuation (Brackets) + Hiragana
+  sqlTest(
+    db,
+    `1.10`,
+    `SELECT highlight(t1, 0, '(', ')') as res FROM t1('「こんにちは」');`,
+    [],
+    ["(「こんにちは」)と言った。"]
+  );
+
+  // Full-width Romaji 
+  sqlTest(
+    db,
+    `1.12`,
+    `SELECT highlight(t1, 0, '(', ')') as res FROM t1('ｗｉｄｔｈ');`,
+    [],
+    ["ｆｕｌｌ(ｗｉｄｔｈ)のテスト"]
+  );
+
+  // Half-width Katakana
+  sqlTest(
+    db,
+    `1.13`,
+    `SELECT highlight(t1, 0, '(', ')') as res FROM t1('ﾝｶｸ');`,
+    [],
+    ["ﾊ(ﾝｶｸ)のﾃｽﾄ"]
+  );
 });
 
 function sqlTest(

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -74,20 +74,30 @@ static const unsigned char sqlite3Utf8Trans1[] = {
     }                                                                          \
   }
 
-static const int CJK[6][2] = {{0x3400, 0x4DBF},   {0x4E00, 0x9FFF},
-                              {0xF900, 0xFAFF},   {0x20000, 0x2EBEF},
-                              {0x2F800, 0x2FA1F}, {0x30000, 0x3134F}};
+static const int CJK[8][2] = {
+    {0x3000, 0x30FF},   // CJK Symbols, Hiragana, Katakana
+    {0x3400, 0x4DBF},   // CJK Unified Ideographs Extension A
+    {0x4E00, 0x9FFF},   // CJK Unified Ideographs
+    {0xF900, 0xFAFF},   // CJK Compatibility Ideographs
+    {0xFF00, 0xFFEF},   // Halfwidth and Fullwidth Forms (incl. Halfwidth Katakana)
+    {0x20000, 0x2EBEF}, // CJK Unified Ideographs Extension B/C/D/E/F
+    {0x2F800, 0x2FA1F}, // CJK Compatibility Ideographs Supplement
+    {0x30000, 0x3134F}  // CJK Unified Ideographs Extension G
+};
+
 // https://jrgraphix.net/research/unicode_blocks.php
 // https://en.wikipedia.org/wiki/CJK_Unified_Ideographs
-// 3400 — 4DBF  	CJK Unified Ideographs Extension A
-// 4E00 — 9FFF  	CJK Unified Ideographs
-// F900 — FAFF  	CJK Compatibility Ideographs
-// 20000 — 2A6DF 2A700-2B73F 2B740–2B81F. 2B820–2CEAF. 2CEB0–2EBEF.	CJK
-// Unified Ideographs Extension B/C/D/E/F 2F800 — 2FA1F  	CJK
-// Compatibility Ideographs Supplement
-//   30000–3134F. CJK Unified Ideographs Extension G
+// 3000 — 30FF    CJK Symbols and Punctuation, Hiragana, Katakana
+// 3400 — 4DBF    CJK Unified Ideographs Extension A
+// 4E00 — 9FFF    CJK Unified Ideographs
+// F900 — FAFF    CJK Compatibility Ideographs
+// FF00 — FFEF    Halfwidth and Fullwidth Forms
+// 20000 — 2EBEF  CJK Unified Ideographs Extension B/C/D/E/F 
+// 2F800 — 2FA1F  CJK Compatibility Ideographs Supplement
+// 30000 — 3134F  CJK Unified Ideographs Extension G
+
 static inline int isCJK(int iCode) {
-  for (int i = 0; i < 6; i++) {
+  for (int i = 0; i < 8; i++) {
     if (iCode < CJK[i][0]) { // smaller
       break;
     }


### PR DESCRIPTION
In Japanese, almost all text is a combination of kanji (Chinese characters), Hiragana, and Katakana. Currently, this tokenizer does not handle them the same. This leads to most searches breaking for Japanese text.

For example, "リンゴを食べます" will lead to "リンゴを" and "べます" being tokenized as trigrams, but "食" will emit a unigram. This will lead to searches such as "食べ" not lead any results, and even trigrams like "を食べ" will not find anything.

Therefore, this PR updates the CJK detector to include full- and halfwidth Hiragana and Katakana as well as Japanese punctuation.